### PR TITLE
update peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hoek": "1.x.x"
   },
   "peerDependencies": {
-    "hapi": "3.x.x"
+    "hapi": ">=2.x.x"
   },
   "devDependencies": {
     "hapi": "3.x.x",


### PR DESCRIPTION
Simple PR, had to update the peerDependency, otherwise could not use with Hapi 3.0.

Tests say:

``` bash
» npm test                  

> hapi-auth-basic@1.0.0 test /Users/david/Dropbox/Code/nodesecurity/hapi-auth-basic
> make test-cov



  ......................

 22 tests complete (104 ms)



 No global variable leaks detected.

Coverage: 100.00%
Coverage succeeded
```

All seems pretty fine :) Also closes this one https://github.com/spumko/hapi-auth-basic/issues/1
