### PR TITLE
issue passing errors to validateFunc

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -379,4 +379,24 @@ describe('Basic', function () {
         expect(fn).to.not.throw(Error);
         done();
     });
+
+    it('should return 500 if validateFunc receives a non-null error value', function(done) {
+
+        server.auth.strategy('test_error_handling', 'basic', { 
+            validateFunc: function(username, password, callback) {
+                return callback({error: 'test error'}, false, null)
+            }
+        });
+
+        server.route({ method: 'GET', path: '/test_error_handling', handler: basicHandler, config: { auth: 'test_error_handling' } })
+
+        var request = { method: 'GET', url: '/test_error_handling', headers: { authorization: basicHeader('john', '12345') } };
+
+        server.inject(request, function (res) {
+
+            expect(res.result).to.exist;
+            expect(res.statusCode).to.equal(500);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
I noticed if you pass a non-null value that is not an instance of Error as err to validateFunc it will return a 200 status code, even with isValid set to false e.g.

```
validateFunc: function(username, password, callback) {
  return callback({error: 'test error'}, false, null)
}
```

This PR just contains a unit case to highlight this, what should the expected behaviour be here?
