### PR TITLE
Support registering a strategy with plugin options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,23 @@ var Hoek = require('hoek');
 
 var internals = {};
 
+internals.defaults = {
+    strategy: {
+        name: 'basic',
+        mode: false,
+        options: {}
+    }
+};
 
 exports.register = function (plugin, options, next) {
 
     plugin.auth.scheme('basic', internals.implementation);
+
+    if (options.strategy) {
+        var strategy = Hoek.applyToDefaults(internals.defaults.strategy, options.strategy);
+        plugin.auth.strategy(strategy.name, 'basic', strategy.mode, strategy.options);
+    }
+
     next();
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -406,4 +406,39 @@ describe('Basic', function () {
             });
         });
     });
+
+    it('should register a strategy if passed as options', function (done) {
+
+      var server = new Hapi.Server();
+      server.pack.register({
+        plugin: require('../'),
+        options: {
+            strategy: {
+                name: 'default',
+                options: {
+                    validateFunc: loadUser
+                }
+            }
+        }
+      }, function (err) {
+
+        expect(err).to.not.exist;
+
+        function route () {
+
+            server.route({ method: 'POST', path: '/basic', handler: basicHandler, config: { auth: 'default' } });
+        }
+
+        expect(route).to.not.throw(Error);
+
+        var request = { method: 'POST', url: '/basic', headers: { authorization: basicHeader('john', '123:45') } };
+
+        server.inject(request, function (res) {
+
+            expect(res.result).to.exist;
+            expect(res.result).to.equal('ok');
+            done();
+        });
+      });
+    });
 });


### PR DESCRIPTION
When using `Pack.compose`, it would be nice to have a strategy registered internally to this plugin if configuration options are specified.

Sorry if the code style doesn't match, I tried to apply techniques I saw in other hapijs repos.
