### PR TITLE
Use ci-plugin template

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -5,26 +5,8 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu, windows, macos]
-        node: ['*', '14', '12']
-        hapi: ['20', '19']
-
-    runs-on: ${{ matrix.os }}-latest
-    name: ${{ matrix.os }} node@${{ matrix.node }} hapi@${{ matrix.hapi }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - name: install
-        run: npm install
-      - name: install hapi
-        run: npm install @hapi/hapi@${{ matrix.hapi }}
-      - name: test
-        run: npm test
+    uses: hapijs/.github/.github/workflows/ci-plugin.yml@master


### PR DESCRIPTION
Following our discussion in https://github.com/hapijs/basic/pull/88. I opened a new PR using the CI template I created in `.github`.

Since we haven't merged the PR in the `.github` repo yet (https://github.com/hapijs/.github/pull/20) I point to the branch `ci-template` there but once it's done we can point to `master` instead. FWIW we can also point to a tag if we decide to version the templates within `.github` repo. The only downside is that we'll have to update every repo to the new tag afterwards. On the other side if we point to `master` we just have to update `.github` and all new pipelines within the org will use the new template automatically. Considering our use case, it is the way to go IMO.

I don't know about you but it definitely feels good to remove pretty much everything from the action workflow file. 😄 